### PR TITLE
Feat export pdf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
+		    <!-- OpenHTMLToPDF -->
+		<dependency>
+			<groupId>com.openhtmltopdf</groupId>
+			<artifactId>openhtmltopdf-pdfbox</artifactId>
+			<version>1.0.10</version>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/itu/eval3/newapp/client/controller/api/PdfApiController.java
+++ b/src/main/java/itu/eval3/newapp/client/controller/api/PdfApiController.java
@@ -1,11 +1,9 @@
 package itu.eval3.newapp.client.controller.api;
 
-import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
-
-import itu.eval3.newapp.client.builder.ApiResponseBuilder;
 import itu.eval3.newapp.client.exceptions.ERPNexException;
 import itu.eval3.newapp.client.models.hr.salary.SalarySlip;
 import itu.eval3.newapp.client.models.user.UserErpNext;
+import itu.eval3.newapp.client.services.exporter.PdfExporterService;
 import itu.eval3.newapp.client.services.hr.salary.SalarySlipService;
 import jakarta.servlet.http.HttpSession;
 
@@ -15,23 +13,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.context.Context;
-
-import java.io.ByteArrayOutputStream;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
 
 @RestController
 @RequestMapping("/api/pdf")
 public class PdfApiController {
 
     @Autowired
-    private TemplateEngine templateEngine;
-    @Autowired
     private SalarySlipService salarySlipService;
-
 
     @GetMapping("/salary-slip/{id}")
     public ResponseEntity<?> sallarySlipPdf(@PathVariable("id") String id, HttpSession session) throws Exception {
@@ -39,33 +27,12 @@ public class PdfApiController {
             id = id.replaceAll("__", "/");
             UserErpNext user = (UserErpNext) session.getAttribute("user");
             SalarySlip salarySlipInstance = salarySlipService.getById(user, id);
-            Context context = new Context();
-            context.setVariable("salarySlip", salarySlipInstance); // ton objet Java
 
-            String html = templateEngine.process("pdf/bulletin-paie", context);
-
-            // Convertir HTML → PDF
-            ByteArrayOutputStream pdfStream = new ByteArrayOutputStream();
-            PdfRendererBuilder builder = new PdfRendererBuilder();
-            builder.useFastMode();
-            builder.withHtmlContent(html, null);
-            builder.toStream(pdfStream);
-            builder.run();
-
-            byte[] pdfBytes = pdfStream.toByteArray();
-
-            // Configurer les headers
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.APPLICATION_PDF);
-            headers.setContentLength(pdfBytes.length);
-            headers.setContentDisposition(ContentDisposition
-                    .attachment()
-                    .filename("bulletin-paie-avril2025.pdf")
-                    .build());
-
-            return new ResponseEntity<>(pdfBytes, headers, HttpStatus.OK);
+            return salarySlipService.exportBulletinPaie(salarySlipInstance);
+        
         } catch (ERPNexException e) {
             return ResponseEntity.badRequest().body(e.getAsApiResponse());
         }
     }
+    
 }

--- a/src/main/java/itu/eval3/newapp/client/controller/api/PdfApiController.java
+++ b/src/main/java/itu/eval3/newapp/client/controller/api/PdfApiController.java
@@ -1,0 +1,64 @@
+package itu.eval3.newapp.client.controller.api;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.io.ByteArrayOutputStream;
+import java.util.*;
+
+@RestController
+@RequestMapping("/api/pdf")
+public class PdfApiController {
+
+    @Autowired
+    private TemplateEngine templateEngine;
+
+    @GetMapping("/sallary-slip")
+    public ResponseEntity<byte[]> sallarySlipPdf() throws Exception {
+        // Données simulées
+        Context context = new Context();
+        context.setVariable("employeeName", "Alain Rakoto");
+        context.setVariable("month", "Avril 2025");
+
+        List<Map<String, Object>> earnings = new ArrayList<>();
+        earnings.add(Map.of("component", "Salaire de base", "amount", 1500000));
+        earnings.add(Map.of("component", "Indemnité", "amount", 450000));
+
+        List<Map<String, Object>> deductions = new ArrayList<>();
+        deductions.add(Map.of("component", "Taxe sociale", "amount", 390000));
+
+        context.setVariable("earnings", earnings);
+        context.setVariable("deductions", deductions);
+        context.setVariable("netPay", 1560000);
+
+        // Générer HTML avec Thymeleaf
+        String html = templateEngine.process("pdf/bulletin-paie", context);
+
+        // Convertir HTML → PDF
+        ByteArrayOutputStream pdfStream = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.useFastMode();
+        builder.withHtmlContent(html, null);
+        builder.toStream(pdfStream);
+        builder.run();
+
+        byte[] pdfBytes = pdfStream.toByteArray();
+
+        // Configurer les headers
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        headers.setContentLength(pdfBytes.length);
+        headers.setContentDisposition(ContentDisposition
+                .attachment()
+                .filename("bulletin-paie-avril2025.pdf")
+                .build());
+
+        return new ResponseEntity<>(pdfBytes, headers, HttpStatus.OK);
+    }
+}

--- a/src/main/java/itu/eval3/newapp/client/controller/api/SalaryApiController.java
+++ b/src/main/java/itu/eval3/newapp/client/controller/api/SalaryApiController.java
@@ -1,5 +1,6 @@
 package itu.eval3.newapp.client.controller.api;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,6 +8,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.thymeleaf.context.Context;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 
 import itu.eval3.newapp.client.builder.ApiResponseBuilder;
 import itu.eval3.newapp.client.exceptions.AuthenticationException;
@@ -54,4 +58,5 @@ public class SalaryApiController {
             return ResponseEntity.badRequest().body(ApiResponseBuilder.DFAULT_BUILDER.error(exc));
         }
     }
+
 }

--- a/src/main/java/itu/eval3/newapp/client/models/hr/salary/SalaryComponent.java
+++ b/src/main/java/itu/eval3/newapp/client/models/hr/salary/SalaryComponent.java
@@ -1,5 +1,7 @@
 package itu.eval3.newapp.client.models.hr.salary;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import itu.eval3.newapp.client.models.action.FrappeDocument;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -9,7 +11,11 @@ import lombok.EqualsAndHashCode;
 public class SalaryComponent extends FrappeDocument{    
     public String type;
     public String description;
+    @JsonProperty("salary_component")
+    public String salaryComponent;
     public double amount;
+    @JsonProperty("year_to_date")
+    public double yearToDate;
 
     public SalaryComponent(){
         super("Salary Component");

--- a/src/main/java/itu/eval3/newapp/client/models/hr/salary/SalarySlip.java
+++ b/src/main/java/itu/eval3/newapp/client/models/hr/salary/SalarySlip.java
@@ -167,4 +167,8 @@ public class SalarySlip extends FrappeDocument{
         // TODO Auto-generated method stub
         
     }
+
+    public String getUriName(){
+        return this.getName().replaceAll("/", "__");
+    }
 }

--- a/src/main/java/itu/eval3/newapp/client/models/hr/salary/SalarySlip.java
+++ b/src/main/java/itu/eval3/newapp/client/models/hr/salary/SalarySlip.java
@@ -1,6 +1,8 @@
 package itu.eval3.newapp.client.models.hr.salary;
 
 import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.util.List;
 
@@ -15,6 +17,8 @@ import lombok.EqualsAndHashCode;
 public class SalarySlip extends FrappeDocument{
 
     private String employee;
+    private String company;
+    private String designation;
 
     @JsonProperty("employee_name")
     private String employeeName;

--- a/src/main/java/itu/eval3/newapp/client/models/hr/salary/SalarySlip.java
+++ b/src/main/java/itu/eval3/newapp/client/models/hr/salary/SalarySlip.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
+import java.util.Calendar;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/itu/eval3/newapp/client/services/exporter/PdfExporterService.java
+++ b/src/main/java/itu/eval3/newapp/client/services/exporter/PdfExporterService.java
@@ -1,0 +1,23 @@
+package itu.eval3.newapp.client.services.exporter;
+
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PdfExporterService {
+    public ResponseEntity<byte[]> exportData(byte[] pdfBytes, String filename){
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        headers.setContentLength(pdfBytes.length);
+        headers.setContentDisposition(ContentDisposition
+                .attachment()
+                .filename(filename+".pdf")
+                .build());
+
+        return new ResponseEntity<>(pdfBytes, headers, HttpStatus.OK);
+    }
+}

--- a/src/main/java/itu/eval3/newapp/client/services/hr/salary/SalarySlipService.java
+++ b/src/main/java/itu/eval3/newapp/client/services/hr/salary/SalarySlipService.java
@@ -40,4 +40,8 @@ public class SalarySlipService extends FrappeCrudService<SalarySlip> {
         return getAllDocuments(user, new SalarySlip(),ApiConfig.ALL_FIELDS, filter, SalarySlip.class);
     }
 
+    public SalarySlip getById(UserErpNext user, String id) throws ERPNexException {
+        return getDocumentById(user, new SalarySlip(), id, null, SalarySlip.class);
+    }
+
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -11856,3 +11856,15 @@ textarea.form-control-lg {
 }
 
 /*# sourceMappingURL=style.css.map */
+
+.download-btn {
+    position: relative;
+    padding: 5px 10px;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.download-btn .spinner {
+    margin-left: 5px;
+    font-size: 14px;
+}

--- a/src/main/resources/templates/hr/salary/list.html
+++ b/src/main/resources/templates/hr/salary/list.html
@@ -38,7 +38,7 @@
                     
                     salaries.forEach(salary => {
                         const row = document.createElement('tr');
-                        const id = salary.name.replaceAll("/", "__"); // "Sal Slip__HR-EMP-00001__00001" // encode le nom dynamiquement côté JS
+                        // "Sal Slip__HR-EMP-00001__00001" // encode le nom dynamiquement côté JS
 
                         row.innerHTML = `
                             <td>${salary.name}</td>
@@ -48,13 +48,59 @@
                             <td>${salary.gross_pay.toFixed(2)}</td>
                             <td>${salary.total_deduction.toFixed(2)}</td>
                             <td>${salary.net_pay.toFixed(2)}</td>
-                            <td><a href="/api/pdf/salary-slip/${id}" target="_blank">PDF</a></td>
+                            <td>
+                                <button class="download-btn" onclick="downloadPdf(this, '${salary.name}')">
+                                    <span class="label">PDF</span>
+                                    <span class="spinner" style="display:none;">⏳</span>
+                                </button>
+                            </td>
+
                         `;
                         salariesBody.appendChild(row);
                     });
                 })
                 .catch(error => console.error('Error fetching salaries:', error));
             });
+
+            function downloadPdf(button, id) {
+                const label = button.querySelector('.label');
+                const spinner = button.querySelector('.spinner');
+
+                const safeId = id.replaceAll("/", "__");
+                const url = `/api/pdf/salary-slip/${safeId}`;
+
+                // Afficher le spinner
+                label.style.display = "none";
+                spinner.style.display = "inline";
+
+                fetch(url)
+                    .then(response => {
+                        if (!response.ok) throw new Error("Erreur lors de la récupération du PDF");
+                        return response.blob();
+                    })
+                    .then(blob => {
+                        const fileName = `bulletin-${id.replaceAll("/", "_")}.pdf`;
+                        const blobUrl = URL.createObjectURL(blob);
+
+                        const a = document.createElement("a");
+                        a.href = blobUrl;
+                        a.download = fileName;
+                        document.body.appendChild(a);
+                        a.click();
+                        document.body.removeChild(a);
+                        URL.revokeObjectURL(blobUrl);
+                    })
+                    .catch(err => {
+                        console.error("Erreur PDF :", err);
+                        alert("Impossible de générer le PDF.");
+                    })
+                    .finally(() => {
+                        // Restaurer le bouton
+                        label.style.display = "inline";
+                        spinner.style.display = "none";
+                    });
+            }
+
     </script>
     </th:block>
 

--- a/src/main/resources/templates/hr/salary/list.html
+++ b/src/main/resources/templates/hr/salary/list.html
@@ -16,6 +16,7 @@
                             <th scope="col">Gain</th>
                             <th scope="col">Deductions</th>
                             <th scope="col">Total</th>
+                            <th scope="col">Actions</th>
                         </thead>
                         <tbody id="salariesBody">
 
@@ -37,6 +38,8 @@
                     
                     salaries.forEach(salary => {
                         const row = document.createElement('tr');
+                        const id = salary.name.replaceAll("/", "__"); // "Sal Slip__HR-EMP-00001__00001" // encode le nom dynamiquement côté JS
+
                         row.innerHTML = `
                             <td>${salary.name}</td>
                             <td>${salary.employee_name}</td>
@@ -45,6 +48,7 @@
                             <td>${salary.gross_pay.toFixed(2)}</td>
                             <td>${salary.total_deduction.toFixed(2)}</td>
                             <td>${salary.net_pay.toFixed(2)}</td>
+                            <td><a href="/api/pdf/salary-slip/${id}" target="_blank">PDF</a></td>
                         `;
                         salariesBody.appendChild(row);
                     });

--- a/src/main/resources/templates/pdf/bulletin-paie.html
+++ b/src/main/resources/templates/pdf/bulletin-paie.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="fr">
+
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            font-size: 12px;
+            color: #333;
+            margin: 40px;
+        }
+
+        header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .logo {
+            width: 150px;
+            height: 80px;
+            border: 1px dashed #ccc;
+            text-align: center;
+            line-height: 80px;
+            font-size: 12px;
+            color: #aaa;
+        }
+
+        h1 {
+            text-align: center;
+            margin: 20px 0;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 15px;
+        }
+
+        th,
+        td {
+            border: 1px solid #ccc;
+            padding: 6px;
+            text-align: left;
+        }
+
+        .no-border td {
+            border: none;
+            padding: 2px 4px;
+        }
+
+        .section-title {
+            background-color: #f2f2f2;
+            padding: 5px;
+            font-weight: bold;
+            margin-top: 15px;
+        }
+
+        .total-row {
+            font-weight: bold;
+            background-color: #f9f9f9;
+        }
+    </style>
+</head>
+
+<body>
+
+    <header>
+        <div class="logo">
+            Logo Entreprise
+        </div>
+        <div style="text-align:right;">
+            <div><strong>Entreprise :</strong> <span th:text="${company}"></span></div>
+            <div><strong>Période :</strong> <span th:text="${startDate}"></span> au <span th:text="${endDate}"></span>
+            </div>
+            <div><strong>Structure :</strong> <span th:text="${salaryStructure}"></span></div>
+        </div>
+    </header>
+
+    <h1>Bulletin de Paie</h1>
+
+    <table class="no-border">
+        <tr>
+            <td><strong>Employé :</strong> <span th:text="${employeeName}"></span></td>
+            <td><strong>Code :</strong> <span th:text="${employee}"></span></td>
+        </tr>
+        <tr>
+            <td><strong>Poste :</strong> <span th:text="${designation}"></span></td>
+            <td><strong>Date :</strong> <span th:text="${postingDate}"></span></td>
+        </tr>
+    </table>
+
+    <div class="section-title">Détails de présence</div>
+    <table>
+        <tr>
+            <th>Jours ouvrés</th>
+            <th>Absences</th>
+            <th>Congés sans solde</th>
+            <th>Jours payés</th>
+        </tr>
+        <tr>
+            <td th:text="${totalWorkingDays}">25</td>
+            <td th:text="${absentDays}">0</td>
+            <td th:text="${leaveWithoutPay}">3</td>
+            <td th:text="${paymentDays}">22</td>
+        </tr>
+    </table>
+
+    <div class="section-title">Gains</div>
+    <table>
+        <tr>
+            <th>Composant</th>
+            <th>Montant (€)</th>
+            <th>Cumul Annuel (€)</th>
+        </tr>
+        <tr th:each="e : ${earnings}">
+            <td th:text="${e.salary_component}">Basic</td>
+            <td th:text="${#numbers.formatDecimal(e.amount, 1, 'COMMA', 2, 'POINT')}">4400.00</td>
+            <td th:text="${#numbers.formatDecimal(e.year_to_date, 1, 'COMMA', 2, 'POINT')}">4400.00</td>
+        </tr>
+    </table>
+
+    <div class="section-title">Déductions</div>
+    <table>
+        <tr>
+            <th>Composant</th>
+            <th>Montant (€)</th>
+            <th>Cumul Annuel (€)</th>
+        </tr>
+        <tr th:each="d : ${deductions}">
+            <td th:text="${d.salary_component}">---</td>
+            <td th:text="${#numbers.formatDecimal(d.amount, 1, 'COMMA', 2, 'POINT')}">---</td>
+            <td th:text="${#numbers.formatDecimal(d.year_to_date, 1, 'COMMA', 2, 'POINT')}">---</td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(deductions)}">
+            <td colspan="3" style="text-align:center;">Aucune déduction</td>
+        </tr>
+    </table>
+
+    <div class="section-title">Résumé</div>
+    <table>
+        <tr class="total-row">
+            <td>Salaire Brut</td>
+            <td colspan="2" th:text="${#numbers.formatDecimal(grossPay, 1, 'COMMA', 2, 'POINT')} + ' €'">4400.00 €</td>
+        </tr>
+        <tr class="total-row">
+            <td>Déductions</td>
+            <td colspan="2" th:text="${#numbers.formatDecimal(totalDeduction, 1, 'COMMA', 2, 'POINT')} + ' €'">0.00 €
+            </td>
+        </tr>
+        <tr class="total-row">
+            <td>Net à Payer</td>
+            <td colspan="2" th:text="${#numbers.formatDecimal(netPay, 1, 'COMMA', 2, 'POINT')} + ' €'">4400.00 €</td>
+        </tr>
+    </table>
+
+    <p><strong>Montant en lettres :</strong> <span th:text="${totalInWords}">EUR Four Thousand, Four Hundred
+            only.</span></p>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/pdf/bulletin-paie.html
+++ b/src/main/resources/templates/pdf/bulletin-paie.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="fr">
-
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -10,13 +9,11 @@
             color: #333;
             margin: 40px;
         }
-
         header {
             display: flex;
             justify-content: space-between;
             align-items: center;
         }
-
         .logo {
             width: 150px;
             height: 80px;
@@ -26,138 +23,126 @@
             font-size: 12px;
             color: #aaa;
         }
-
         h1 {
             text-align: center;
             margin: 20px 0;
         }
-
         table {
             width: 100%;
             border-collapse: collapse;
             margin-bottom: 15px;
         }
-
-        th,
-        td {
+        th, td {
             border: 1px solid #ccc;
             padding: 6px;
             text-align: left;
         }
-
         .no-border td {
             border: none;
             padding: 2px 4px;
         }
-
         .section-title {
             background-color: #f2f2f2;
             padding: 5px;
             font-weight: bold;
             margin-top: 15px;
         }
-
         .total-row {
             font-weight: bold;
             background-color: #f9f9f9;
         }
     </style>
 </head>
-
 <body>
 
-    <header>
-        <div class="logo">
-            Logo Entreprise
-        </div>
-        <div style="text-align:right;">
-            <div><strong>Entreprise :</strong> <span th:text="${company}"></span></div>
-            <div><strong>Période :</strong> <span th:text="${startDate}"></span> au <span th:text="${endDate}"></span>
-            </div>
-            <div><strong>Structure :</strong> <span th:text="${salaryStructure}"></span></div>
-        </div>
-    </header>
+<header>
+    <div class="logo">
+        Logo
+    </div>
+    <div style="text-align:right;">
+        <div><strong>Entreprise :</strong> <span th:text="${salarySlip.company}">Itu Eval</span></div>
+        <div><strong>Période :</strong> <span th:text="${salarySlip.startDate}"></span> au <span th:text="${salarySlip.endDate}"></span></div>
+        <div><strong>Structure :</strong> <span th:text="${salarySlip.salaryStructure}"></span></div>
+    </div>
+</header>
 
-    <h1>Bulletin de Paie</h1>
+<h1>Bulletin de Paie</h1>
 
-    <table class="no-border">
-        <tr>
-            <td><strong>Employé :</strong> <span th:text="${employeeName}"></span></td>
-            <td><strong>Code :</strong> <span th:text="${employee}"></span></td>
-        </tr>
-        <tr>
-            <td><strong>Poste :</strong> <span th:text="${designation}"></span></td>
-            <td><strong>Date :</strong> <span th:text="${postingDate}"></span></td>
-        </tr>
-    </table>
+<table class="no-border">
+    <tr>
+        <td><strong>Employé :</strong> <span th:text="${salarySlip.employeeName}"></span></td>
+        <td><strong>Code :</strong> <span th:text="${salarySlip.employee}"></span></td>
+    </tr>
+    <tr>
+        <td><strong>Poste :</strong> <span th:text="${salarySlip.designation}"></span></td>
+        <td><strong>Date :</strong> <span th:text="${salarySlip.postingDate}"></span></td>
+    </tr>
+</table>
 
-    <div class="section-title">Détails de présence</div>
-    <table>
-        <tr>
-            <th>Jours ouvrés</th>
-            <th>Absences</th>
-            <th>Congés sans solde</th>
-            <th>Jours payés</th>
-        </tr>
-        <tr>
-            <td th:text="${totalWorkingDays}">25</td>
-            <td th:text="${absentDays}">0</td>
-            <td th:text="${leaveWithoutPay}">3</td>
-            <td th:text="${paymentDays}">22</td>
-        </tr>
-    </table>
+<div class="section-title">Détails de présence</div>
+<table>
+    <tr>
+        <th>Jours ouvrés</th>
+        <th>Absences</th>
+        <th>Congés sans solde</th>
+        <th>Jours payés</th>
+    </tr>
+    <tr>
+        <td th:text="${salarySlip.totalWorkingDays}">25</td>
+        <td th:text="${salarySlip.absentDays}">0</td>
+        <td th:text="${salarySlip.leaveWithoutPay}">3</td>
+        <td th:text="${salarySlip.paymentDays}">22</td>
+    </tr>
+</table>
 
-    <div class="section-title">Gains</div>
-    <table>
-        <tr>
-            <th>Composant</th>
-            <th>Montant (€)</th>
-            <th>Cumul Annuel (€)</th>
-        </tr>
-        <tr th:each="e : ${earnings}">
-            <td th:text="${e.salary_component}">Basic</td>
-            <td th:text="${#numbers.formatDecimal(e.amount, 1, 'COMMA', 2, 'POINT')}">4400.00</td>
-            <td th:text="${#numbers.formatDecimal(e.year_to_date, 1, 'COMMA', 2, 'POINT')}">4400.00</td>
-        </tr>
-    </table>
+<div class="section-title">Gains</div>
+<table>
+    <tr>
+        <th>Composant</th>
+        <th>Montant (€)</th>
+        <th>Cumul Annuel (€)</th>
+    </tr>
+    <tr th:each="e : ${salarySlip.earnings}">
+        <td th:text="${e.salaryComponent}">Basic</td>
+        <td th:text="${#numbers.formatDecimal(e.amount, 1, 'COMMA', 2, 'POINT')}">4400.00</td>
+        <td th:text="${#numbers.formatDecimal(e.yearToDate, 1, 'COMMA', 2, 'POINT')}">4400.00</td>
+    </tr>
+</table>
 
-    <div class="section-title">Déductions</div>
-    <table>
-        <tr>
-            <th>Composant</th>
-            <th>Montant (€)</th>
-            <th>Cumul Annuel (€)</th>
-        </tr>
-        <tr th:each="d : ${deductions}">
-            <td th:text="${d.salary_component}">---</td>
-            <td th:text="${#numbers.formatDecimal(d.amount, 1, 'COMMA', 2, 'POINT')}">---</td>
-            <td th:text="${#numbers.formatDecimal(d.year_to_date, 1, 'COMMA', 2, 'POINT')}">---</td>
-        </tr>
-        <tr th:if="${#lists.isEmpty(deductions)}">
-            <td colspan="3" style="text-align:center;">Aucune déduction</td>
-        </tr>
-    </table>
+<div class="section-title">Déductions</div>
+<table>
+    <tr>
+        <th>Composant</th>
+        <th>Montant (€)</th>
+        <th>Cumul Annuel (€)</th>
+    </tr>
+    <tr th:each="d : ${salarySlip.deductions}">
+        <td th:text="${d.salaryComponent}">---</td>
+        <td th:text="${#numbers.formatDecimal(d.amount, 1, 'COMMA', 2, 'POINT')}">---</td>
+        <td th:text="${#numbers.formatDecimal(d.yearToDate, 1, 'COMMA', 2, 'POINT')}">---</td>
+    </tr>
+    <tr th:if="${#lists.isEmpty(salarySlip.deductions)}">
+        <td colspan="3" style="text-align:center;">Aucune déduction</td>
+    </tr>
+</table>
 
-    <div class="section-title">Résumé</div>
-    <table>
-        <tr class="total-row">
-            <td>Salaire Brut</td>
-            <td colspan="2" th:text="${#numbers.formatDecimal(grossPay, 1, 'COMMA', 2, 'POINT')} + ' €'">4400.00 €</td>
-        </tr>
-        <tr class="total-row">
-            <td>Déductions</td>
-            <td colspan="2" th:text="${#numbers.formatDecimal(totalDeduction, 1, 'COMMA', 2, 'POINT')} + ' €'">0.00 €
-            </td>
-        </tr>
-        <tr class="total-row">
-            <td>Net à Payer</td>
-            <td colspan="2" th:text="${#numbers.formatDecimal(netPay, 1, 'COMMA', 2, 'POINT')} + ' €'">4400.00 €</td>
-        </tr>
-    </table>
+<div class="section-title">Résumé</div>
+<table>
+    <tr class="total-row">
+        <td>Salaire Brut</td>
+        <td colspan="2" th:text="${#numbers.formatDecimal(salarySlip.grossPay, 1, 'COMMA', 2, 'POINT')} + ' €'">4400.00 €</td>
+    </tr>
+    <tr class="total-row">
+        <td>Déductions</td>
+        <td colspan="2" th:text="${#numbers.formatDecimal(salarySlip.totalDeduction, 1, 'COMMA', 2, 'POINT')} + ' €'">0.00 €</td>
+    </tr>
+    <tr class="total-row">
+        <td>Net à Payer</td>
+        <td colspan="2" th:text="${#numbers.formatDecimal(salarySlip.netPay, 1, 'COMMA', 2, 'POINT')} + ' €'">4400.00 €</td>
+    </tr>
+</table>
 
-    <p><strong>Montant en lettres :</strong> <span th:text="${totalInWords}">EUR Four Thousand, Four Hundred
-            only.</span></p>
+<p><strong>Montant en lettres :</strong> <span th:text="${salarySlip.totalInWords}">EUR Four Thousand, Four Hundred only.</span></p>
 
 </body>
-
 </html>


### PR DESCRIPTION
# Export PDF features

- generer un pdf a partir d''un template pour Fiche de paie
- nomenclature des fichiers 
- telechargement auto du fichier par lien

## Summary by Sourcery

Implement a PDF export feature for salary slips using Thymeleaf templates and OpenHTMLToPDF, expose it via a new API endpoint, and integrate download links in the UI

New Features:
- Add PDF export endpoint for salary slips to download generated PDFs

Enhancements:
- Extend SalarySlipService with methods to fetch by ID and generate/export PDF
- Enhance SalarySlip and SalaryComponent models with additional fields and JSON mappings
- Add Actions column in salary list UI for PDF download links

Build:
- Add OpenHTMLToPDF dependency for HTML-to-PDF conversion